### PR TITLE
Fix: put back original Wordpress chart content

### DIFF
--- a/bitnami/wordpress/templates/deployment.yaml
+++ b/bitnami/wordpress/templates/deployment.yaml
@@ -23,7 +23,7 @@ spec:
         {{- end }}
       {{- end }}
     spec:
-      {{- include "wordpress.imagePullSecrets" . | nindent 6 }}
+{{- include "wordpress.imagePullSecrets" . | indent 6 }}
       {{- if .Values.schedulerName }}
       schedulerName: {{ .Values.schedulerName | quote }}
       {{- end }}
@@ -44,6 +44,9 @@ spec:
       securityContext:
         runAsUser: {{ .Values.securityContext.runAsUser }}
         fsGroup: {{ .Values.securityContext.fsGroup }}
+      {{- end }}
+      {{- if .Values.initContainers }}
+      initContainers: {{- include "wordpress.tplValue" (dict "value" .Values.initContainers "context" $) | nindent 8 }}
       {{- end }}
       containers:
         - name: wordpress
@@ -84,6 +87,8 @@ spec:
               value: {{ .Values.wordpressLastName | quote }}
             - name: WORDPRESS_HTACCESS_OVERRIDE_NONE
               value: {{ ternary "yes" "no" .Values.allowOverrideNone | quote }}
+            - name: WORDPRESS_HTACCESS_PERSISTENCE_ENABLED
+              value: {{ ternary "yes" "no" .Values.htaccessPersistenceEnabled | quote }}
             - name: WORDPRESS_BLOG_NAME
               value: {{ .Values.wordpressBlogName | quote }}
             - name: WORDPRESS_SKIP_INSTALL
@@ -143,6 +148,8 @@ spec:
               {{- if .Values.livenessProbeHeaders }}
               httpHeaders: {{- toYaml .Values.livenessProbeHeaders | nindent 16 }}
               {{- end }}
+          {{- else if .Values.customLivenessProbe }}
+          livenessProbe: {{- include "wordpress.tplValue" (dict "value" .Values.customLivenessProbe "context" $) | nindent 12 }}
           {{- end }}
           {{- if .Values.readinessProbe.enabled }}
           readinessProbe:
@@ -160,6 +167,8 @@ spec:
               {{- if .Values.readinessProbeHeaders }}
               httpHeaders: {{- toYaml .Values.readinessProbeHeaders | nindent 16 }}
               {{- end }}
+          {{- else if .Values.customReadinessProbe }}
+          readinessProbe: {{- include "wordpress.tplValue" (dict "value" .Values.customReadinessProbe "context" $) | nindent 12 }}
           {{- end }}
           volumeMounts:
             - mountPath: /bitnami/wordpress
@@ -181,7 +190,7 @@ spec:
           imagePullPolicy: {{ .Values.metrics.image.pullPolicy | quote }}
           command:
             - /bin/apache_exporter
-            - -scrape_uri
+            - --scrape_uri
             - http://status.localhost:8080/server-status/?auto
           ports:
             - name: metrics

--- a/bitnami/wordpress/values.yaml
+++ b/bitnami/wordpress/values.yaml
@@ -14,7 +14,7 @@
 image:
   registry: docker.io
   repository: bitnami/wordpress
-  tag: 5.3.2-debian-10-r43
+  tag: 5.4.1-debian-10-r20
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -92,6 +92,7 @@ wordpressSkipInstall: false
 ##  rollingUpdate:
 ##    maxSurge: 25%
 ##    maxUnavailable: 25%
+##
 updateStrategy:
   type: RollingUpdate
 
@@ -105,7 +106,14 @@ allowEmptyPassword: true
 ##
 allowOverrideNone: false
 
-# ConfigMap with custom wordpress-htaccess.conf file (requires allowOverrideNone to true)
+## Persist the custom changes of the htaccess. It depends on the value of
+## `.Values.allowOverrideNone`, when `yes` it will persist `/opt/bitnami/wordpress/wordpress-htaccess.conf`
+## if `no` it will persist `/opt/bitnami/wordpress/.htaccess`
+##
+htaccessPersistenceEnabled: false
+
+## ConfigMap with custom wordpress-htaccess.conf file (requires allowOverrideNone to true)
+##
 customHTAccessCM:
 
 ## Use an alternate scheduler, e.g. "stork".
@@ -139,6 +147,7 @@ extraEnv: []
 ##   - name: ca-cert
 ##     subPath: ca_cert
 ##     mountPath: /path/to/ca_cert
+##
 extraVolumeMounts: []
 
 ## Additional volumes
@@ -150,6 +159,7 @@ extraVolumeMounts: []
 ##      items:
 ##        - key: ca-cert
 ##          path: ca_cert
+##
 extraVolumes: []
 
 ## WordPress containers' resource requests and limits
@@ -190,10 +200,12 @@ securityContext:
   runAsUser: 1001
 
 ## Allow health checks to be pointed at the https port
+##
 healthcheckHttps: false
 
 ## WordPress pod extra options for liveness and readiness probes
 ## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
+##
 livenessProbe:
   enabled: true
   initialDelaySeconds: 120
@@ -208,6 +220,11 @@ readinessProbe:
   timeoutSeconds: 5
   failureThreshold: 6
   successThreshold: 1
+
+## Custom liveness and readiness probes, it overrides the default one (evaluated as a template)
+##
+customLivenessProbe: {}
+customReadinessProbe: {}
 
 ## If using an HTTPS-terminating load-balancer, the probes may need to behave
 ## like the balancer to prevent HTTP 302 responses. According to the Kubernetes
@@ -247,6 +264,7 @@ service:
   ##   http: <to set explicitly, choose port between 30000-32767>
   ##   https: <to set explicitly, choose port between 30000-32767>
   ##   metrics: <to set explicitly, choose port between 30000-32767>
+  ##
   nodePorts:
     http: ""
     https: ""
@@ -258,22 +276,28 @@ service:
   annotations: {}
   ## Limits which cidr blocks can connect to service's load balancer
   ## Only valid if service.type: LoadBalancer
+  ##
   loadBalancerSourceRanges: []
   ## Extra ports to expose (normally used with the `sidecar` value)
   # extraPorts:
 
-## Ingress paramaters
+## Configure the ingress resource that allows you to access the
+## WordPress installation. Set up the URL
+## ref: http://kubernetes.io/docs/user-guide/ingress/
 ##
 ingress:
   ## Set to true to enable ingress record generation
   ##
   enabled: false
+
   ## Set this to true in order to add the corresponding annotations for cert-manager
   ##
   certManager: false
+
   ## When the ingress is enabled, a host pointing to this will be created
   ##
-  hostname: discourse.local
+  hostname: wordpress.local
+
   ## Ingress annotations done as key:value pairs
   ## For a full list of possible ingress annotations, please see
   ## ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md
@@ -281,17 +305,28 @@ ingress:
   ## If certManager is set to true, annotation kubernetes.io/tls-acme: "true" will automatically be set
   ##
   annotations: {}
+
+  ## Enable TLS configuration for the hostname defined at ingress.hostname parameter
+  ## TLS certificates will be retrieved from a TLS secret with name: {{- printf "%s-tls" .Values.ingress.hostname }}
+  ## You can use the ingress.secrets parameter to create this TLS secret or relay on cert-manager to create it
+  ##
+  tls: false
+
   ## The list of additional hostnames to be covered with this ingress record.
   ## Most likely the hostname above will be enough, but in the event more hosts are needed, this is an array
   ## extraHosts:
-  ## - name: discourse.local
+  ## - name: wordpress.local
   ##   path: /
+  ##
+
   ## The tls configuration for additional hostnames to be covered with this ingress record.
   ## see: https://kubernetes.io/docs/concepts/services-networking/ingress/#tls
   ## extraTls:
   ## - hosts:
-  ##     - discourse.local
-  ##   secretName: discourse.local-tls
+  ##     - wordpress.local
+  ##   secretName: wordpress.local-tls
+  ##
+
   ## If you're providing your own certificates, please use this to add the certificates as secrets
   ## key and certificate should start with -----BEGIN CERTIFICATE----- or
   ## -----BEGIN RSA PRIVATE KEY-----
@@ -303,9 +338,10 @@ ingress:
   ## Please see README.md for more information
   ##
   secrets: []
-  ## - name: discourse.local-tls
+  ## - name: wordpress.local-tls
   ##   key:
   ##   certificate:
+  ##
 
 ## Enable persistence using Persistent Volume Claims
 ## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
@@ -334,8 +370,10 @@ persistence:
 ##
 mariadb:
   ## Whether to deploy a mariadb server to satisfy the applications database requirements. To use an external database set this to false and configure the externalDatabase parameters
+  ##
   enabled: true
   ## Disable MariaDB replication
+  ##
   replication:
     enabled: false
 
@@ -406,7 +444,7 @@ metrics:
   image:
     registry: docker.io
     repository: bitnami/apache-exporter
-    tag: 0.7.0-debian-10-r44
+    tag: 0.8.0-debian-10-r50
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.
@@ -415,6 +453,7 @@ metrics:
     # pullSecrets:
     #   - myRegistryKeySecretName
   ## Metrics exporter pod Annotation and Labels
+  ##
   podAnnotations:
     prometheus.io/scrape: "true"
     prometheus.io/port: "9117"
@@ -429,21 +468,26 @@ metrics:
   ## Prometheus Service Monitor
   ## ref: https://github.com/coreos/prometheus-operator
   ##      https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#endpoint
+  ##
   serviceMonitor:
     ## If the operator is installed in your cluster, set to true to create a Service Monitor Entry
+    ##
     enabled: false
     ## Specify the namespace in which the serviceMonitor resource will be created
     # namespace: ""
     ## Specify the interval at which metrics should be scraped
+    ##
     interval: 30s
     ## Specify the timeout after which the scrape is ended
     # scrapeTimeout: 30s
     ## Specify Metric Relabellings to add to the scrape endpoint
     # relabellings:
     ## Specify honorLabels parameter to add the scrape endpoint
+    ##
     honorLabels: false
     ## Used to pass Labels that are used by the Prometheus installed in your cluster to select Service Monitors to work with
     ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#prometheusspec
+    ##
     additionalLabels: {}
 
 ## Add sidecars to the pod.
@@ -457,3 +501,14 @@ metrics:
 ##         containerPort: 1234
 ##
 sidecars: {}
+
+## Add init containers to the pod.
+## ref: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
+## Example:
+## initContainers:
+##  - name: your-image-name
+##    image: your-image
+##    imagePullPolicy: Always
+##    command: ['sh', '-c', 'copy themes and plugins from git and push to /bitnami/wordpress/wp-conntent. Should work with extraVolumeMounts and extraVolumes']
+##
+initContainers: {}


### PR DESCRIPTION
I've erroneously changed the wordpress helm-chart content. I've copied the original content from the original repo and put it back with this PR.